### PR TITLE
refactor: simplify Docker workflows and upgrade GoReleaser config

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,21 +26,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta
@@ -62,65 +50,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push by digest
-        id: build
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: ${{ matrix.platform }}
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-24.04
-    if: ${{ github.event_name != 'pull_request' }}
-    needs:
-      - build
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: heartleo/webdav-115drive
-          tags: |
-            type=raw,value=${{ inputs.tag || 'latest' }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Inspect image
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -26,21 +26,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          # - linux/arm64
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta
@@ -63,64 +51,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push by digest
-        id: build
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          platforms: ${{ matrix.platform }}
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-24.04
-    needs:
-      - build
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/heartleo/webdav-115drive
-          tags: |
-            type=raw,value=${{ inputs.tag || 'latest' }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Inspect image
         run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,15 +35,17 @@ builds:
 # Archive configuration
 archives:
   - id: default
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_
-      {{- .Version }}_
+      {{- .Tag }}_
       {{- .Os }}_
       {{- .Arch }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - README.md
       - LICENSE
@@ -52,7 +54,7 @@ archives:
 
 # Checksums
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'
+  name_template: '{{ .ProjectName }}_{{ .Tag }}_checksums.txt'
   algorithm: sha256
 
 # Changelog generation based on Conventional Commits
@@ -85,73 +87,28 @@ changelog:
     - title: 'Other Changes'
       order: 999
 
-# Docker image configuration
-dockers:
-  # Build for amd64
-  - id: docker-amd64
-    use: buildx
-    goos: linux
-    goarch: amd64
+# Docker image configuration (v2)
+dockers_v2:
+  - id: webdav-115drive
     dockerfile: Dockerfile.goreleaser
-    image_templates:
-      - "heartleo/webdav-115drive:{{ .Tag }}-amd64"
-      - "ghcr.io/heartleo/webdav-115drive:{{ .Tag }}-amd64"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.description=A WebDAV service for 115drive"
-      - "--label=org.opencontainers.image.url=https://github.com/heartleo/webdav-115drive"
-      - "--label=org.opencontainers.image.source=https://github.com/heartleo/webdav-115drive"
-      - "--label=org.opencontainers.image.version={{ .Tag }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.licenses=MIT"
-
-  # Build for arm64
-  - id: docker-arm64
-    use: buildx
-    goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile.goreleaser
-    image_templates:
-      - "heartleo/webdav-115drive:{{ .Tag }}-arm64"
-      - "ghcr.io/heartleo/webdav-115drive:{{ .Tag }}-arm64"
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.description=A WebDAV service for 115drive"
-      - "--label=org.opencontainers.image.url=https://github.com/heartleo/webdav-115drive"
-      - "--label=org.opencontainers.image.source=https://github.com/heartleo/webdav-115drive"
-      - "--label=org.opencontainers.image.version={{ .Tag }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.licenses=MIT"
-
-# Docker manifest configuration (multi-arch images)
-docker_manifests:
-  # Docker Hub manifests
-  - name_template: "heartleo/webdav-115drive:{{ .Tag }}"
-    image_templates:
-      - "heartleo/webdav-115drive:{{ .Tag }}-amd64"
-      - "heartleo/webdav-115drive:{{ .Tag }}-arm64"
-
-  - name_template: "heartleo/webdav-115drive:latest"
-    skip_push: auto
-    image_templates:
-      - "heartleo/webdav-115drive:{{ .Tag }}-amd64"
-      - "heartleo/webdav-115drive:{{ .Tag }}-arm64"
-
-  # GHCR manifests
-  - name_template: "ghcr.io/heartleo/webdav-115drive:{{ .Tag }}"
-    image_templates:
-      - "ghcr.io/heartleo/webdav-115drive:{{ .Tag }}-amd64"
-      - "ghcr.io/heartleo/webdav-115drive:{{ .Tag }}-arm64"
-
-  - name_template: "ghcr.io/heartleo/webdav-115drive:latest"
-    skip_push: auto
-    image_templates:
-      - "ghcr.io/heartleo/webdav-115drive:{{ .Tag }}-amd64"
-      - "ghcr.io/heartleo/webdav-115drive:{{ .Tag }}-arm64"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    images:
+      - "heartleo/webdav-115drive"
+      - "ghcr.io/heartleo/webdav-115drive"
+    tags:
+      - "{{ .Tag }}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+    labels:
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.description: "A WebDAV service for 115drive"
+      org.opencontainers.image.url: "https://github.com/heartleo/webdav-115drive"
+      org.opencontainers.image.source: "https://github.com/heartleo/webdav-115drive"
+      org.opencontainers.image.version: "{{ .Tag }}"
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.licenses: "MIT"
 
 # GitHub Release configuration
 release:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -4,6 +4,7 @@ RUN apk --no-cache add ca-certificates tzdata
 
 WORKDIR /
 
-COPY webdav-115drive /webdav-115drive
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/webdav-115drive /webdav-115drive
 
 ENTRYPOINT ["/webdav-115drive"]


### PR DESCRIPTION
## Summary

- Simplified Docker Hub and GHCR workflows by removing complex digest-based multi-platform builds
- Upgraded GoReleaser configuration to v2 `dockers_v2` API for cleaner multi-arch image builds
- Updated Dockerfile.goreleaser to properly handle multi-platform builds using `TARGETPLATFORM` ARG
- Standardized version templating to use `{{ .Tag }}` consistently across configurations

## Changes

### Workflow Improvements
- Removed matrix-based digest build/merge jobs in both Docker Hub and GHCR workflows
- Consolidated into single-job workflows using native `platforms` parameter
- Added GitHub Actions cache support (`cache-from`/`cache-to`) for faster builds
- Maintained manual trigger support with configurable tag input

### GoReleaser v2 Migration
- Migrated from legacy `dockers` to modern `dockers_v2` configuration
- Simplified multi-platform build definition (no separate builds per architecture)
- Automatic `latest` tag generation for non-prerelease versions
- Consistent OCI labels across all images

### Dockerfile Updates
- Added `TARGETPLATFORM` ARG to support GoReleaser's multi-platform binary placement
- Updated COPY instruction to reference platform-specific binary paths

## Test plan

- [ ] Verify Docker Hub workflow builds successfully on Go code changes
- [ ] Verify GHCR workflow builds successfully (amd64 only currently)
- [ ] Test GoReleaser configuration with a test release tag
- [ ] Confirm multi-platform images are properly built and tagged
- [ ] Validate `latest` tag is only applied to non-prerelease versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)